### PR TITLE
Implementation report for aiocoap

### DIFF
--- a/draft-bormann-t2trg-slipmux.md
+++ b/draft-bormann-t2trg-slipmux.md
@@ -370,6 +370,21 @@ https://github.com/Lobaro/util-slip
 ~~~
 {: artwork-align="center"}
 
+## aiocoap
+
+A work in progress implementation of slipmux is a vailable as part of
+the aiocoap library (MIT License, Python language, for unconstrained systems):
+
+<https://codeberg.org/aiocoap/aiocoap/pulls/52>
+
+Implementation was generally straightforward,
+thanks to reusing the precise {{RFC7252}} format.
+Minor problem points were obtaining test vectors for FCS calculation
+(interoperating with the earlier Rust implementation by Bennet Hattesen helped),
+tolerating the lowercasing normalization of the device name that comes from {{Section 6.2.2.1 of ?RFC3986}},
+and overriding the library's defaults on when to send the Uri-Host option.
+Troubles around binding servers to serial ports stem from the general library's shortcomings and not from this specification.
+
 Acknowledgements
 ================
 {: unnumbered}

--- a/draft-bormann-t2trg-slipmux.md
+++ b/draft-bormann-t2trg-slipmux.md
@@ -373,7 +373,7 @@ https://github.com/Lobaro/util-slip
 ## aiocoap
 
 A work in progress implementation of slipmux is a vailable as part of
-the aiocoap library (MIT License, Python language, for unconstrained systems):
+the aiocoap library (MIT License, Python language, for capable systems):
 
 <https://codeberg.org/aiocoap/aiocoap/pulls/52>
 


### PR DESCRIPTION
Beyond the things that gave me trouble, one aspect not covered in the document are port numbers. They don't really have a place in the transport, but setting them in a Uri-Port option might be practical, especially for when an MCU has more UARTs it fans out to, as that'd allow the main entry point to do simple port based reverse proxying (with barely any real need to do more than forwarding messages, as long as it does not issue requests itself downstream), and then they need support in the URI. This might be easier though when going with the more generic coap:// scheme as per my transport-indication recommendations.